### PR TITLE
Destroy handle for data socket after transfer

### DIFF
--- a/lib/AnyEvent/FTP/Client/Role/StoreTransfer.pm
+++ b/lib/AnyEvent/FTP/Client/Role/StoreTransfer.pm
@@ -25,6 +25,7 @@ sub xfer
     else
     {
       $handle->push_shutdown;
+      $handle->destroy;
     }
   });
 }


### PR DESCRIPTION
Hi,
I've experienced that the number of sockets in use by a script which is constantly connecting to various ftp servers and putting files is increasing with time.
After digging into the problem I've found out that sockets used for data transfer (I've used ftp passive mode) are never closed.
As far as I was able to understand your code I've succeeded to solve the problem by destroying the Anyevent::Handle after transfer.
Please check this solution.